### PR TITLE
fix(shell connector): redirect stderr in the connector result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>1.7.0</version>
+			<version>3.12.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/bonitasoft/connectors/scripting/ShellConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/scripting/ShellConnector.java
@@ -136,7 +136,7 @@ public class ShellConnector extends AbstractConnector {
         String args[] = { interpreterInput, parameterInput, script.getCanonicalPath() };
         Process process = null;
 		try {
-			process = Runtime.getRuntime().exec(args);
+            process = new ProcessBuilder(args).redirectErrorStream(true).start();
             return process;
 		} finally{
 			if(process != null){

--- a/src/main/java/org/bonitasoft/connectors/scripting/ShellConnector.java
+++ b/src/main/java/org/bonitasoft/connectors/scripting/ShellConnector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012-2013 BonitaSoft S.A.
+ * Copyright (C) 2012-2019 BonitaSoft S.A.
  * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation
@@ -13,7 +13,10 @@
  **/
 package org.bonitasoft.connectors.scripting;
 
+import static java.util.Optional.ofNullable;
+
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -29,7 +32,6 @@ import org.bonitasoft.engine.connector.ConnectorValidationException;
 
 /**
  * @author Matthieu Chaffotte, Yanyan Liu, Hongwen Zang, Arthur Freycon
- * 
  */
 public class ShellConnector extends AbstractConnector {
 
@@ -39,9 +41,10 @@ public class ShellConnector extends AbstractConnector {
 
     private static final String SCRIPT = "script";
 
-    private Logger LOGGER = Logger.getLogger(this.getClass().getName());
+    private static final Logger LOGGER = Logger.getLogger(ShellConnector.class.getName());
 
     public ShellConnector() {
+        // do nothing
     }
 
     public Object getExitStatus() {
@@ -54,23 +57,27 @@ public class ShellConnector extends AbstractConnector {
 
     @Override
     public void validateInputParameters() throws ConnectorValidationException {
-        final List<String> errors = new ArrayList<String>(3);
+        final List<String> errors = new ArrayList<>();
         final String interpreter = (String) getInputParameter(INTERPRETER);
-        if (interpreter == null || !(interpreter.length() > 0)) {
+        if (isNullOrEmpty(interpreter)) {
             errors.add("interpreter cannot be empty!");
         }
         final String parameter = (String) getInputParameter(PARAMETER);
-        if (parameter == null || !(parameter.length() > 0)) {
+        if (isNullOrEmpty(parameter)) {
             errors.add("parameter cannot be empty!");
         }
         final String shell = (String) getInputParameter(SCRIPT);
-        if (shell == null || !(shell.length() > 0)) {
+        if (isNullOrEmpty(shell)) {
             errors.add("script cannot be empty!");
         }
 
         if (!errors.isEmpty()) {
             throw new ConnectorValidationException(this, errors);
         }
+    }
+
+    private static boolean isNullOrEmpty(String string) {
+        return string == null || string.isEmpty();
     }
 
     @Override
@@ -88,15 +95,12 @@ public class ShellConnector extends AbstractConnector {
             setOutputParameter("result", processOutput);
             setOutputParameter("exitStatus", process.waitFor());
             if(!script.delete()){
-            	LOGGER.info("Script not cleaned after connector execution."+script.getName());
+                LOGGER.info("Script not cleaned after connector execution." + script.getName());
             }
-
         } catch (Exception e) {
             throw new ConnectorException(e.getMessage(), e.getCause());
         } finally {
-            if (process != null) {
-                process.destroy();
-            }
+            ofNullable(process).ifPresent(Process::destroy);
         }
     }
 
@@ -107,21 +111,13 @@ public class ShellConnector extends AbstractConnector {
     }
 
     private File createExecutableScript(final String scriptInput) throws IOException {
-        FileWriter fw = null;
-        try {
-            File tmpFile = File.createTempFile("script", getExtension());
-            tmpFile.setExecutable(true);
-            tmpFile.deleteOnExit();
-            fw = new FileWriter(tmpFile);
+        File tmpFile = File.createTempFile("script", getExtension());
+        tmpFile.setExecutable(true);
+        tmpFile.deleteOnExit();
+        try (FileWriter fw = new FileWriter(tmpFile)) {
             fw.write(scriptInput);
-            return tmpFile;
-        } finally {
-            try {
-                if (fw != null) fw.close();
-            } catch (Exception e) {
-                LOGGER.warning("Unable to close " + fw.toString());
-            }
         }
+        return tmpFile;
     }
 
     private String getExtension() {
@@ -134,7 +130,6 @@ public class ShellConnector extends AbstractConnector {
             return ".sh";
         else
             return "";
-    
     }
 
     private Process runScript(final String interpreterInput, final String parameterInput, File script) throws IOException {
@@ -142,52 +137,39 @@ public class ShellConnector extends AbstractConnector {
         Process process = null;
 		try {
 			process = Runtime.getRuntime().exec(args);
-		} catch (IOException e) {
-			e.printStackTrace();
+            return process;
 		} finally{
 			if(process != null){
-				// close unused streams
-				try {
-					process.getOutputStream().close();
-				} catch (IOException e) {
-					LOGGER.warning("Unable to close " + e.getMessage());
-				}
-				try {
-					process.getErrorStream().close();
-				} catch (IOException e) {
-					LOGGER.warning("Unable to close " + e.getMessage());
-				}			
+                closeQuietly(process.getOutputStream());
+                closeQuietly(process.getErrorStream());
 			}
 		}
-        
-        return process;
     }
 
     private String consumeProcessOutput(Process process) throws IOException {
-        BufferedReader scriptOutputReader = null;
-        final InputStream processInputStream = process.getInputStream();
-		try {
-            scriptOutputReader = new BufferedReader(new InputStreamReader(processInputStream));
-            String line = scriptOutputReader.readLine();
+        try (InputStream processInputStream = process.getInputStream()) {
             StringBuilder builder = new StringBuilder();
-            String lineSep = System.getProperty("line.separator");
-            while (line != null) {
-                builder.append(line);
-                builder.append(lineSep);
-                line = scriptOutputReader.readLine();
+            try (BufferedReader scriptOutputReader = new BufferedReader(new InputStreamReader(processInputStream))) {
+                String line = scriptOutputReader.readLine();
+                String lineSep = System.getProperty("line.separator");
+                while (line != null) {
+                    builder.append(line);
+                    builder.append(lineSep);
+                    line = scriptOutputReader.readLine();
+                }
             }
             return builder.toString();
-        } finally {
+        }
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        if (closeable != null) {
             try {
-                if (scriptOutputReader != null){
-                	scriptOutputReader.close();
-                }
-                if (processInputStream != null){
-                	processInputStream.close();
-                }
-            } catch (Exception e) {
-                LOGGER.warning("Unable to close process inpustream");
+                closeable.close();
+            } catch (IOException e) {
+                LOGGER.warning("Unable to close " + e.getMessage());
             }
         }
     }
+
 }

--- a/src/test/java/org/bonitasoft/connectors/scripting/ConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/scripting/ConnectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 BonitaSoft S.A.
+ * Copyright (C) 2012-2019 BonitaSoft S.A.
  * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation
@@ -11,7 +11,9 @@
  * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
  * Floor, Boston, MA 02110-1301, USA.
  **/
-package org.bonita.connector.scripting.shell.test;
+package org.bonitasoft.connectors.scripting;
+
+import static org.junit.Assume.assumeTrue;
 
 import java.util.logging.Logger;
 
@@ -21,9 +23,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 /**
- * 
  * @author Matthieu Chaffotte, Yanyan Liu, Hongwen Zang
- * 
  */
 public abstract class ConnectorTest {
 
@@ -49,18 +49,26 @@ public abstract class ConnectorTest {
 
     };
 
-    private final String os = System.getProperty("os.name").toLowerCase();
+    private static final String os = System.getProperty("os.name").toLowerCase();
 
-    protected boolean isWindows() {
+    protected static boolean isWindows() {
         return os.contains("win");
     }
 
-    protected boolean isMac() {
+    protected static boolean isMac() {
         return os.contains("mac");
     }
 
-    protected boolean isUnix() {
+    protected static boolean isUnix() {
         return os.contains("nix") || os.contains("nux");
+    }
+
+    protected static void assumeIsMacOrUnix() {
+        assumeTrue(isMac() || isUnix());
+    }
+
+    protected static void assumeIsWindows() {
+        assumeTrue(isWindows());
     }
 
 }

--- a/src/test/java/org/bonitasoft/connectors/scripting/GroovyConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/scripting/GroovyConnectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 BonitaSoft S.A.
+ * Copyright (C) 2012-2019 BonitaSoft S.A.
  * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation
@@ -11,7 +11,7 @@
  * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
  * Floor, Boston, MA 02110-1301, USA.
  **/
-package org.bonitasoft.connectors.scripting.groovy.test;
+package org.bonitasoft.connectors.scripting;
 
 import static org.junit.Assert.assertEquals;
 
@@ -20,13 +20,15 @@ import java.util.HashMap;
 import org.bonitasoft.connectors.scripting.GroovyConnector;
 import org.bonitasoft.engine.connector.ConnectorException;
 import org.bonitasoft.engine.connector.ConnectorValidationException;
+import org.junit.Test;
 
 /**
  * @author Baptiste Mesta
  */
 public class GroovyConnectorTest {
 
-    public void executeSimpleScript() throws Exception {
+    @Test
+    public void should_execute_simple_script() throws Exception {
         assertEquals("test", executeConnectorWith("test"));
     }
 

--- a/src/test/java/org/bonitasoft/connectors/scripting/ShellConnectorTest.java
+++ b/src/test/java/org/bonitasoft/connectors/scripting/ShellConnectorTest.java
@@ -134,6 +134,22 @@ public class ShellConnectorTest extends ConnectorTest {
         assertThat(shell.getExitStatus()).as("exit status").isEqualTo(0);
     }
 
+    @Test
+    public void should_result_contains_standard_error_content() throws Exception {
+        final Map<String, Object> parameters = new HashMap<>();
+        parameters.put("interpreter", defaultOsInterpreter());
+        parameters.put("parameter", defaultOsParameter());
+        if (isWindows()) {
+            parameters.put("script", script("@echo off", "java -version"));
+        } else {
+            parameters.put("script", script("java -version"));
+        }
+
+        ShellConnector shell = validateAndExecute(parameters);
+        assertThat(shell.getExitStatus()).as("exit status").isEqualTo(0);
+        assertThat((String) shell.getResult()).isNotEmpty();
+    }
+
     // =================================================================================================================
     // UTILS
     // =================================================================================================================


### PR DESCRIPTION
Previously, only stdin was redirected in the result, so command like
'java -version' where not available

Relates to [BS-19345](https://bonitasoft.atlassian.net/browse/BS-19345)